### PR TITLE
Fix retention_policy warning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -306,20 +306,11 @@ resource "azurerm_monitor_diagnostic_setting" "diag" {
     content {
       category = log.value
       enabled  = true
-
-      retention_policy {
-        enabled = false
-        days    = 0
-      }
     }
   }
 
   metric {
     category = "AllMetrics"
     enabled  = true
-
-    retention_policy {
-      enabled = false
-    }
   }
 }


### PR DESCRIPTION
│ Warning: Argument is deprecated
│
│   with azurerm_monitor_diagnostic_setting.diag,
│   on main.tf line 297, in resource "azurerm_monitor_diagnostic_setting" "diag":
│  297: resource "azurerm_monitor_diagnostic_setting" "diag" {
│
│ `retention_policy` has been deprecated in favor of `azurerm_storage_management_policy` resource - to learn more https://aka.ms/diagnostic_settings_log_retention

The retention_policy block is optional from version 2.8.0, so it can be removed.